### PR TITLE
Removing the warning about packages.config on build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -31,16 +31,17 @@ skip_branch_with_pr: true
 branches:
   # Whitelist
   only:
-    - develop
     - master
-    - /release/.*/
+    - /support/.*/
     - /hotfix/.*/
+    - /feature/.*/
+    - /bugfix/.*/
 
 #---------------------------------#
 #  Build Cache                    #
 #---------------------------------#
 cache:
-- tools -> build.cake, tools/packages.config
+- tools -> build.cake
 
 #---------------------------------#
 #  Skip builds for doc changes    #


### PR DESCRIPTION
Fixes #3
Removes packages.config from the cache in appveyor
Adding feature and bugfix branches to the build